### PR TITLE
signalDistortion in Phone Calls

### DIFF
--- a/saltychat/SaltyClient/VoiceManager.cs
+++ b/saltychat/SaltyClient/VoiceManager.cs
@@ -190,7 +190,7 @@ namespace SaltyClient
                         VoiceManager._serverUniqueIdentifier,
                         new PhoneCommunication(
                             client.TeamSpeakName,
-                            signalDistortion
+                            10 - signalDistortion
                         )
                     )
                 );


### PR DESCRIPTION
GetZoneScumminess returns a value between 0 - 5, where 5 is the best signal.
With the current code, if both parties are in a 5/5 signal range, their call will have the worst quality, because the best signal of the plugin is specified as 0. This simple PR fixes this problem.