### PR TITLE
Add 2 client exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ Parameter | Type | Description
 ------------ | ------------- | -------------
 primary | `bool` | Whether to get the primary or secondary channel
 
+### GetRadioVolume
+Returns the current radio volume as float (0.0f - 1.6f).
+
+### GetVoiceRange
+Returns the current voice range as float.
+
 ### SetRadioChannel
 Set the current radio channel.
 
@@ -88,12 +94,6 @@ Adjust the radio's volume
 Parameter | Type | Description
 ------------ | ------------- | -------------
 volumeLevel | `float` | Overrides the volume in percent (0f - 1.6f / 0 - 160%)
-
-### GetRadioVolume
-Get the curren radio volume, returns a float
-
-### GetVoiceRange
-Get the currently set voice-range/proximity, returns a float ( possible values as defined in config.json)
 
 ## Server
 ### SetPlayerAlive

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Parameter | Type | Description
 ------------ | ------------- | -------------
 volumeLevel | `float` | Overrides the volume in percent (0f - 1.6f / 0 - 160%)
 
+### GetRadioVolume
+Get the curren radio volume, returns a float
+
+### GetVoiceRange
+Get the currently set voice-range/proximity, returns a float ( possible values as defined in config.json)
+
 ## Server
 ### SetPlayerAlive
 Sets player `IsAlive` flag.

--- a/saltychat/SaltyClient/VoiceManager.cs
+++ b/saltychat/SaltyClient/VoiceManager.cs
@@ -44,6 +44,8 @@ namespace SaltyClient
 
         #region Delegates
         public delegate string GetRadioChannelDelegate(bool primary);
+        public delegate float GetRadioVolumeDelegate();
+        public delegate float GetVoiceRangeDelegate();
         #endregion
 
         #region CTOR
@@ -56,9 +58,13 @@ namespace SaltyClient
             API.RegisterNuiCallbackType(NuiEvent.SaltyChat_OnNuiReady);
 
             GetRadioChannelDelegate getRadioChannelDelegate = new GetRadioChannelDelegate(this.GetRadioChannel);
+            GetRadioVolumeDelegate getRadioVolumeDelegate = new GetRadioVolumeDelegate(this.GetRadioVolume);
+            GetVoiceRangeDelegate getVoiceRangeDelegate = new GetVoiceRangeDelegate(this.GetVoiceRange);
             this.Exports.Add("GetRadioChannel", getRadioChannelDelegate);
             this.Exports.Add("SetRadioChannel", new Action<string, bool>(this.SetRadioChannel));
             this.Exports.Add("SetRadioVolume", new Action<float>(this.SetRadioVolume));
+            this.Exports.Add("GetRadioVolume", getRadioVolumeDelegate);
+            this.Exports.Add("GetVoiceRange", getVoiceRangeDelegate);
 
             VoiceManager.PlayerList = this.Players;
         }
@@ -228,6 +234,12 @@ namespace SaltyClient
                     this._voiceClients.Remove(serverId);
                 }
             }
+        }
+
+        [EventHandler(Event.SaltyChat_IsIngame)]
+        private void OnIsIngame(Action<bool> callBack)
+        {
+            callBack.Invoke(this.IsIngame);
         }
         #endregion
 
@@ -474,6 +486,13 @@ namespace SaltyClient
         }
         #endregion
 
+        #region Exports (General)
+        internal float GetVoiceRange()
+        {
+            return this.VoiceRange;
+        }
+        #endregion
+
         #region Exports (Radio)
         internal string GetRadioChannel(bool primary)
         {
@@ -500,6 +519,11 @@ namespace SaltyClient
                 this.RadioVolume = 1.6f;
             else
                 this.RadioVolume = volumeLevel;
+        }
+
+        internal float GetRadioVolume()
+        {
+            return this.RadioVolume;
         }
         #endregion
 

--- a/saltychat/SaltyClient/VoiceManager.cs
+++ b/saltychat/SaltyClient/VoiceManager.cs
@@ -235,12 +235,6 @@ namespace SaltyClient
                 }
             }
         }
-
-        [EventHandler(Event.SaltyChat_IsIngame)]
-        private void OnIsIngame(Action<bool> callBack)
-        {
-            callBack.Invoke(this.IsIngame);
-        }
         #endregion
 
         #region Remote Events (Phone)

--- a/saltychat/SaltyClient/VoiceManager.cs
+++ b/saltychat/SaltyClient/VoiceManager.cs
@@ -61,10 +61,10 @@ namespace SaltyClient
             GetRadioVolumeDelegate getRadioVolumeDelegate = new GetRadioVolumeDelegate(this.GetRadioVolume);
             GetVoiceRangeDelegate getVoiceRangeDelegate = new GetVoiceRangeDelegate(this.GetVoiceRange);
             this.Exports.Add("GetRadioChannel", getRadioChannelDelegate);
-            this.Exports.Add("SetRadioChannel", new Action<string, bool>(this.SetRadioChannel));
-            this.Exports.Add("SetRadioVolume", new Action<float>(this.SetRadioVolume));
             this.Exports.Add("GetRadioVolume", getRadioVolumeDelegate);
             this.Exports.Add("GetVoiceRange", getVoiceRangeDelegate);
+            this.Exports.Add("SetRadioChannel", new Action<string, bool>(this.SetRadioChannel));
+            this.Exports.Add("SetRadioVolume", new Action<float>(this.SetRadioVolume));
 
             VoiceManager.PlayerList = this.Players;
         }
@@ -480,7 +480,7 @@ namespace SaltyClient
         }
         #endregion
 
-        #region Exports (General)
+        #region Exports (Proximity)
         internal float GetVoiceRange()
         {
             return this.VoiceRange;


### PR DESCRIPTION
Adds the following exports:
- GetRadioVolume -> Returns the current volume of the radio as a float(set by the SetVolume-Export)
- GetVoiceRange -> Returns the currently active voice range (as set by the keybind)

Everything is documented in the export section of the README.