### PR TITLE
changed: you can't talk on the radio while swimming

### DIFF
--- a/saltychat/SaltyClient/VoiceManager.cs
+++ b/saltychat/SaltyClient/VoiceManager.cs
@@ -779,7 +779,7 @@ namespace SaltyClient
                     this.IsUsingMegaphone = false;
                 }
 
-                if (this.PrimaryRadioChannel != null)
+                if (this.PrimaryRadioChannel != null && !Game.PlayerPed.IsSwimming && !Game.PlayerPed.IsSwimmingUnderWater)
                 {
                     Game.DisableControlThisFrame(0, (Control)this.Configuration.TalkPrimary);
 
@@ -795,7 +795,7 @@ namespace SaltyClient
                     }
                 }
 
-                if (this.SecondaryRadioChannel != null)
+                if (this.SecondaryRadioChannel != null && !Game.PlayerPed.IsSwimming && !Game.PlayerPed.IsSwimmingUnderWater)
                 {
                     Game.DisableControlThisFrame(0, (Control)this.Configuration.TalkSecondary);
 


### PR DESCRIPTION
I made it so that the player can't talk over the radio while swimming.
If the player starts talking on the radio while on the ground and then walks/jumps into the water, he's still on the radio - I'm working on a fix for that, I made this on like 20 seconds lol.
It's a basic, but necessary change.