### PR TITLE
Fixed error : Unable to cast object of type 'System.Byte' to type 'Sy…

### DIFF
--- a/saltychat/SaltyServer/VoiceManager.cs
+++ b/saltychat/SaltyServer/VoiceManager.cs
@@ -149,7 +149,7 @@ namespace SaltyServer
         {
             PhoneCall phoneCall = this.GetPhoneCall(identifier, true);
 
-            foreach (int playerHandle in players.Cast<int>())
+            foreach (int playerHandle in players)
             {
                 VoiceClient voiceClient = this.VoiceClients.FirstOrDefault(c => c.Player.GetServerId() == playerHandle);
 
@@ -169,7 +169,7 @@ namespace SaltyServer
             if (phoneCall == null)
                 return;
 
-            foreach (int playerHandle in players.Cast<int>())
+            foreach (int playerHandle in players)
             {
                 VoiceClient voiceClient = this.VoiceClients.FirstOrDefault(c => c.Player.GetServerId() == playerHandle);
 


### PR DESCRIPTION
…stem.Int32'. When adding or removing players from a call.

On an Ubuntu 18.04 FiveM server, I've had an error : SCRIPT ERROR in reference call: System.InvalidCastException: Unable to cast object of type 'System.Byte' to type 'System.Int32'. when trying to "AddPlayersToCall" and "RemovePlayersFromCall". 

Was working on Windows server but not on Ubuntu. 

Issue was fixed by removing the force cast to int32 of the player ID in the int[] of players id. 
Works on windows. 

GCPhone line:  exports.saltychat:AddPlayersToCall(tostring(id), {tonumber(AppelsEnCours[id].transmitter_src), tonumber(AppelsEnCours[id].receiver_src)}) that works now.